### PR TITLE
Fix feed URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,10 +32,9 @@ Once it's deployed, paste the deployment address into your auto updater code:
 
 ```js
 const { app, autoUpdater } = require('electron')
-const { resolve } = require('url')
 
 const server = <your-deployment-url>
-const feed = resolve(server, 'update', process.platform, app.getVersion())
+const feed = `${server}/update/${process.platform}/${app.getVersion()}`
 
 autoUpdater.setFeedURL(feed)
 ```


### PR DESCRIPTION
Current example using [`url.resolve()`](https://nodejs.org/api/url.html#url_url_resolve_from_to) does not work, so replaced it.