### PR TITLE
Fix caching with prereleases

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -44,7 +44,9 @@ const cacheReleaseList = async url => {
 
 exports.refreshCache = async () => {
   const repo = ACCOUNT + '/' + REPOSITORY
-  const url = `https://api.github.com/repos/${repo}/releases?per_page=1`
+  const url = PRE
+    ? `https://api.github.com/repos/${repo}/releases?per_page=20`
+    : `https://api.github.com/repos/${repo}/releases/latest`
 
   const response = await fetch(url, {
     headers: {
@@ -58,16 +60,20 @@ exports.refreshCache = async () => {
 
   const data = await response.json()
 
-  if (!Array.isArray(data) || data.length === 0) {
+  if (data.length === 0) {
     return
   }
 
-  const release = data[0]
+  let release = data
 
-  // Only accept prereleases when the `PRE` env
-  // variables is defined
-  if (PRE && !release.prerelease) {
-    return
+  if (Array.isArray(data)) {
+    // Find the first non-draft release or prerelease
+    release = data.find(item => {
+      return !item.draft && item.prerelease === PRE
+    })
+    if (!release) {
+      return
+    }
   }
 
   if (!release.assets || !Array.isArray(release.assets)) {


### PR DESCRIPTION
This PR: fetch latest stable release or fetch last 20 releases to find a non-draft prerelease. 

For now, cache system fetches release with `https://api.github.com/repos/${repo}/releases?per_page=1`. And there is 2 problems with that:
* In non-`PRE` mode: It returns a release but this release can be a draft or a prerelease. Using [releases/latest](https://developer.github.com/v3/repos/releases/#get-the-latest-release) prevents this.
* In `PRE`mode: If the last release is a stable release, it doesn't return latest prerelease

Fetching 20 releases is completely arbitrary, but seems enough. No need to scan all releases with pagination system for prerelease. I can maybe put it in an ENV variable to tweak it but it seems over-engineered