### PR TITLE
Make /download work for Windows

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -14,7 +14,7 @@ exports.download = (req, res) => {
   if (userAgent.isMac) {
     platform = 'darwin'
   } else if (userAgent.isWindows) {
-    platform = 'win32'
+    platform = 'exe'
   }
 
   // Get the latest version from the cache


### PR DESCRIPTION
Fixes issue #19 

When using the `/download` route, the platform set for windows was `win32` but the cache would set the platform to `exe`. The platform for windows in the `/download` route is now set to `exe`.