### PR TITLE
Added support for private repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ node_modules
 
 # logs
 npm-debug.log
+
+# Docker
+Dockerfile
+.dockerignore
+docker-*
+env.list

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
+# OS
+.DS_Store
+
 # dependencies
 node_modules
 
 # logs
 npm-debug.log
-
-# Docker
-Dockerfile
-.dockerignore
-docker-*
-env.list

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-# OS
-.DS_Store
-
-# dependencies
 node_modules
-
-# logs
-npm-debug.log

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,28 +6,36 @@ const convertStream = require('stream-to-string')
 const checkPlatform = require('./platform')
 
 const latest = {}
-const { ACCOUNT, REPOSITORY, PRE, GH_TOKEN, PRIVATE_BASE_URL } = process.env
+const {
+  ACCOUNT,
+  REPOSITORY,
+  PRE,
+  TOKEN,
+  URL: PRIVATE_BASE_URL,
+  NOW_URL
+} = process.env
+const baseUrl = NOW_URL || PRIVATE_BASE_URL
 
 if (!ACCOUNT || !REPOSITORY) {
   console.error('Neither ACCOUNT, nor REPOSITORY are defined')
   process.exit(1)
 }
 
-if (GH_TOKEN && !PRIVATE_BASE_URL) {
-  console.error('PRIVATE_BASE_URL missing')
+if (TOKEN && !baseUrl) {
+  console.error('Neither NOW_URL, nor URL are defined.')
   process.exit(1)
 }
 
-if (!GH_TOKEN && PRIVATE_BASE_URL) {
-  console.error('GH_TOKEN missing')
+if (!TOKEN && baseUrl) {
+  console.error('TOKEN missing')
   process.exit(1)
 }
 
 const cacheReleaseList = async url => {
   const headers = { Accept: 'application/vnd.github.preview' }
 
-  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
-    headers.Authorization = `token ${GH_TOKEN}`
+  if (TOKEN && typeof TOKEN === 'string' && TOKEN.length > 0) {
+    headers.Authorization = `token ${TOKEN}`
   }
 
   const { status, body } = await fetch(url, { headers })
@@ -59,8 +67,8 @@ exports.refreshCache = async () => {
   const url = `https://api.github.com/repos/${repo}/releases?per_page=100`
   const headers = { Accept: 'application/vnd.github.preview' }
 
-  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
-    headers.Authorization = `token ${GH_TOKEN}`
+  if (TOKEN && typeof TOKEN === 'string' && TOKEN.length > 0) {
+    headers.Authorization = `token ${TOKEN}`
   }
 
   const response = await fetch(url, { headers })

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,19 +6,31 @@ const convertStream = require('stream-to-string')
 const checkPlatform = require('./platform')
 
 const latest = {}
-const { ACCOUNT, REPOSITORY, PRE } = process.env
+const { ACCOUNT, REPOSITORY, PRE, GH_TOKEN, PRIVATE_BASE_URL } = process.env
 
 if (!ACCOUNT || !REPOSITORY) {
   console.error('Neither ACCOUNT, nor REPOSITORY are defined')
   process.exit(1)
 }
 
+if (GH_TOKEN && !PRIVATE_BASE_URL) {
+  console.error('PRIVATE_BASE_URL missing')
+  process.exit(1)
+}
+
+if (!GH_TOKEN && PRIVATE_BASE_URL) {
+  console.error('GH_TOKEN missing')
+  process.exit(1)
+}
+
 const cacheReleaseList = async url => {
-  const { status, body } = await fetch(url, {
-    headers: {
-      Accept: 'application/vnd.github.preview'
-    }
-  })
+  const headers = { Accept: 'application/vnd.github.preview' }
+
+  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+    headers.Authorization = `token ${GH_TOKEN}`
+  }
+
+  const { status, body } = await fetch(url, { headers })
 
   if (status !== 200) {
     return
@@ -45,12 +57,13 @@ const cacheReleaseList = async url => {
 exports.refreshCache = async () => {
   const repo = ACCOUNT + '/' + REPOSITORY
   const url = `https://api.github.com/repos/${repo}/releases?per_page=100`
+  const headers = { Accept: 'application/vnd.github.preview' }
 
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'application/vnd.github.preview'
-    }
-  })
+  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+    headers.Authorization = `token ${GH_TOKEN}`
+  }
+
+  const response = await fetch(url, { headers })
 
   if (response.status !== 200) {
     return
@@ -88,7 +101,7 @@ exports.refreshCache = async () => {
   latest.platforms = {}
 
   for (const asset of release.assets) {
-    const { name, browser_download_url } = asset
+    const { name, url, browser_download_url, content_type } = asset
 
     if (name === 'RELEASES') {
       await cacheReleaseList(browser_download_url)
@@ -101,7 +114,11 @@ exports.refreshCache = async () => {
       continue
     }
 
-    latest.platforms[platform] = browser_download_url
+    latest.platforms[platform] = {
+      name,
+      url,
+      content_type
+    }
   }
 
   console.log(`Finished caching version ${tag_name}`)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,12 +13,13 @@ const { GH_TOKEN, PRIVATE_BASE_URL } = process.env
 // Helpers
 const proxyPrivateDownload = (asset, req, res) => {
   const redirect = 'follow'
-  const headers = {
-    Accept: 'application/octet-stream',
-    Authorization: `token ${GH_TOKEN}`
-  }
+  const headers = { Accept: 'application/octet-stream' }
   const options = { headers, redirect }
-  const { url, name, content_type: contentType } = asset
+  const { url: rawUrl, name, content_type: contentType } = asset
+  const url = rawUrl.replace(
+    'https://api.github.com/',
+    `https://${GH_TOKEN}@api.github.com/`
+  )
 
   res.setHeader('Content-Type', contentType)
   res.setHeader('Content-Disposition', `attachment; filename="${name}"`)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -2,10 +2,31 @@
 const { send } = require('micro')
 const { valid, gt } = require('semver')
 const { parse } = require('express-useragent')
+const fetch = require('node-fetch')
 
 // Utilities
 const { loadCache } = require('./cache')
 const checkAlias = require('./aliases')
+
+const { GH_TOKEN, PRIVATE_BASE_URL } = process.env
+
+// Helpers
+const proxyPrivateDownload = (asset, req, res) => {
+  const redirect = 'follow'
+  const headers = {
+    Accept: 'application/octet-stream',
+    Authorization: `token ${GH_TOKEN}`
+  }
+  const options = { headers, redirect }
+  const { url, name, content_type: contentType } = asset
+
+  res.setHeader('Content-Type', contentType)
+  res.setHeader('Content-Disposition', `attachment; filename="${name}"`)
+
+  fetch(url, options).then(assetRes => {
+    send(res, 200, assetRes.body)
+  })
+}
 
 exports.download = (req, res) => {
   const userAgent = parse(req.headers['user-agent'])
@@ -25,8 +46,13 @@ exports.download = (req, res) => {
     return
   }
 
+  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+    proxyPrivateDownload(platforms[platform], req, res)
+    return
+  }
+
   res.writeHead(302, {
-    Location: platforms[platform]
+    Location: platforms[platform].url
   })
 
   res.end()
@@ -51,15 +77,20 @@ exports.downloadPlatform = (req, res) => {
     return
   }
 
+  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+    proxyPrivateDownload(latest.platforms[platform], req, res)
+    return
+  }
+
   res.writeHead(302, {
-    Location: latest.platforms[platform]
+    Location: latest.platforms[platform].url
   })
 
   res.end()
 }
 
 exports.update = (req, res) => {
-  let { platform, version } = req.params
+  const { platform: platformName, version } = req.params
 
   if (!valid(version)) {
     send(res, 500, {
@@ -70,7 +101,7 @@ exports.update = (req, res) => {
     return
   }
 
-  platform = checkAlias(platform)
+  const platform = checkAlias(platformName)
 
   if (!platform) {
     send(res, 500, {
@@ -98,7 +129,7 @@ exports.update = (req, res) => {
       name: latest.version,
       notes,
       pub_date,
-      url: latest.platforms[platform]
+      url: `${PRIVATE_BASE_URL}/download/${platformName}`
     })
 
     return

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -8,7 +8,8 @@ const fetch = require('node-fetch')
 const { loadCache } = require('./cache')
 const checkAlias = require('./aliases')
 
-const { GH_TOKEN, PRIVATE_BASE_URL } = process.env
+const { TOKEN, URL: PRIVATE_BASE_URL, NOW_URL } = process.env
+const baseUrl = NOW_URL || PRIVATE_BASE_URL
 
 // Helpers
 const proxyPrivateDownload = (asset, req, res) => {
@@ -18,7 +19,7 @@ const proxyPrivateDownload = (asset, req, res) => {
   const { url: rawUrl, name, content_type: contentType } = asset
   const url = rawUrl.replace(
     'https://api.github.com/',
-    `https://${GH_TOKEN}@api.github.com/`
+    `https://${TOKEN}@api.github.com/`
   )
 
   res.setHeader('Content-Type', contentType)
@@ -47,7 +48,7 @@ exports.download = (req, res) => {
     return
   }
 
-  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+  if (TOKEN && typeof TOKEN === 'string' && TOKEN.length > 0) {
     proxyPrivateDownload(platforms[platform], req, res)
     return
   }
@@ -78,7 +79,7 @@ exports.downloadPlatform = (req, res) => {
     return
   }
 
-  if (GH_TOKEN && typeof GH_TOKEN === 'string' && GH_TOKEN.length > 0) {
+  if (TOKEN && typeof TOKEN === 'string' && TOKEN.length > 0) {
     proxyPrivateDownload(latest.platforms[platform], req, res)
     return
   }
@@ -130,7 +131,7 @@ exports.update = (req, res) => {
       name: latest.version,
       notes,
       pub_date,
-      url: `${PRIVATE_BASE_URL}/download/${platformName}`
+      url: `${baseUrl}/download/${platformName}`
     })
 
     return

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,8 @@ You'll be asked for the value of two environment variables:
 - `ACCOUNT`: Your username or organisation name on GitHub
 - `REPOSITORY`: The name of the repository to pull releases from
 - `PORT`: The port on which Hazel should run
-- `GH_TOKEN`: GitHub token (used for private repository)
-- `PRIVATE_BASE_URL`: Server base url (used for private repository)
+- `TOKEN`: GitHub token (used for private repository)
+- `URL` or `NOW_URL`: Server base url (used for private repository)
 
 Once it's deployed, paste the deployment address into your code (please keep in mind that updates should only occur in the production version of the app, not while developing):
 

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,8 @@ You'll be asked for the value of two environment variables:
 - `ACCOUNT`: Your username or organisation name on GitHub
 - `REPOSITORY`: The name of the repository to pull releases from
 - `PORT`: The port on which Hazel should run
+- `GH_TOKEN`: GitHub token (used for private repository)
+- `PRIVATE_BASE_URL`: Server base url (used for private repository)
 
 Once it's deployed, paste the deployment address into your code (please keep in mind that updates should only occur in the production version of the app, not while developing):
 

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,8 @@ You'll be asked for the value of two environment variables:
 - `ACCOUNT`: Your username or organisation name on GitHub
 - `REPOSITORY`: The name of the repository to pull releases from
 - `PORT`: The port on which Hazel should run
-- `TOKEN`: GitHub token (used for private repository)
-- `URL` or `NOW_URL`: Server base url (used for private repository)
+- `TOKEN`: Your GitHub token (for private repos)
+- `URL` or `NOW_URL`: The server's URL (for private repos - when running on [Now](https://zeit.co/now), this field is filled with the URL of the deployment automatically)
 
 Once it's deployed, paste the deployment address into your code (please keep in mind that updates should only occur in the production version of the app, not while developing):
 


### PR DESCRIPTION
This PR allows to set two new environment variables to enable support for private repos:

* `GH_TOKEN` - GitHub personal access token needed to access the private repo.
* `PRIVATE_BASE_URL` - Base URL of the update server (e.g. update.example.com).

Both are required to make hazel work with private repos.

The `proxyPrivateDownload` helper found in [routes.js](https://github.com/mifitto/hazel/blob/79675b901523adfcf450f1b808c80ceae3159a3e/lib/routes.js#L14) uses [node-fetch](https://github.com/bitinn/node-fetch) to proxy the private file through hazel. This obviously leads to higher server load and increased bandwidth usage, but should be okay for this specific use case 😸 
