### PR TITLE
Fix private github repo assets link

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -106,7 +106,7 @@ exports.refreshCache = async () => {
   latest.platforms = {}
 
   for (const asset of release.assets) {
-    const { name, browser_download_url, content_type } = asset
+    const { name, browser_download_url, url, content_type } = asset
 
     if (name === 'RELEASES') {
       await cacheReleaseList(browser_download_url)
@@ -121,6 +121,7 @@ exports.refreshCache = async () => {
 
     latest.platforms[platform] = {
       name,
+      api_url: url,
       url: browser_download_url,
       content_type
     }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -18,7 +18,7 @@ const proxyPrivateDownload = (asset, req, res) => {
   const redirect = 'follow'
   const headers = { Accept: 'application/octet-stream' }
   const options = { headers, redirect }
-  const { url: rawUrl, name, content_type: contentType } = asset
+  const { api_url: rawUrl, name, content_type: contentType } = asset
   const url = rawUrl.replace(
     'https://api.github.com/',
     `https://${TOKEN}@api.github.com/`


### PR DESCRIPTION
This fixes the private repo asset download that was introduced in #23 but got removed in 04c94ee9284cef739d85aa17009164e576bccbb5 because of #26.

cc: @leo 