### PR TITLE
Proxy private release assets via S3 url

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,20 +15,18 @@ const shouldProxyPrivateDownload =
 
 // Helpers
 const proxyPrivateDownload = (asset, req, res) => {
-  const redirect = 'follow'
+  const redirect = 'manual'
   const headers = { Accept: 'application/octet-stream' }
   const options = { headers, redirect }
-  const { api_url: rawUrl, name, content_type: contentType } = asset
+  const { api_url: rawUrl } = asset
   const url = rawUrl.replace(
     'https://api.github.com/',
     `https://${TOKEN}@api.github.com/`
   )
 
-  res.setHeader('Content-Type', contentType)
-  res.setHeader('Content-Disposition', `attachment; filename="${name}"`)
-
   fetch(url, options).then(assetRes => {
-    send(res, 200, assetRes.body)
+    res.setHeader('Location', assetRes.headers.get('Location'))
+    send(res, 302)
   })
 }
 


### PR DESCRIPTION
This PR attempts to improve the initial implementation introduced in #23 by @dominiklessel for downloading private repo release assets. 

The API url available for every asset, on being hit with the right headers redirects to the github release asset url which is a presigned s3 url for the asset. So instead of fetching the actual asset, I've changed the fetch for the api endpoint to not follow all redirects. Instead we stop at the redirect, read the `Location` header and redirect the client to that `Location`.

eg: `now-desktop` 3.6.2 mac asset has api url: 
`https://api.github.com/repos/zeit/now-desktop/releases/assets/5302341`

which returns this:

```
https://github-production-release-asset-2e65be.s3.amazonaws.com/62052858/12b2020e-c612-11e7-88db-297f985951ed?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20171113%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20171113T143717Z&X-Amz-Expires=300&X-Amz-Signature=b487dcc04f9c620357df58bad1d19b680a620b5af46a0de745589e33f4224e6d&X-Amz-SignedHeaders=host&actor_id=1824298&response-content-disposition=attachment%3B%20filename%3Dnow-desktop-3.6.2-mac.zip&response-content-type=application%2Foctet-stream
``` 

Couple of advantages:
- Reuse Github CDN so downloads are faster for users everywhere
- Don't eat up server bandwidth which is chargeable if you're on AWS
- Removes the burden to set content-length (currently missing in hazel) and content-type of the asset from hazel

I've tested this out and released it for downloads of https://pyrite.network and it seems to be working perfectly. 