### PR TITLE
Only check if versions differ (even if lower)

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,6 @@
 // Packages
 const { send } = require('micro')
-const { valid, gt } = require('semver')
+const { valid, compare } = require('semver')
 const { parse } = require('express-useragent')
 const fetch = require('node-fetch')
 
@@ -125,7 +125,17 @@ module.exports = ({ cache, config }) => {
       return
     }
 
-    if (gt(latest.version, version)) {
+    // Previously, we were checking if the latest version is
+    // greater than the one on the client. However, we
+    // only need to compare if they're different (even if
+    // lower) in order to trigger an update.
+
+    // This allows developers to downgrade their users
+    // to a lower version in the case that a major bug happens
+    // that will take a long time to fix and release
+    // a patch update.
+
+    if (compare(latest.version, version) !== 0) {
       const { notes, pub_date } = latest
 
       send(res, 200, {


### PR DESCRIPTION
While working on Hyper Canary releases, @chabou and I discovered that it makes much more sense to update if the version from the client is different from the latest version, not just if the latest version is higher than the client one.

This allows developers to downgrade their users to a lower version in the case that a major bug happens that will take a long time to fix and release a patch update.

It also covers many other situations in which developers might have gotten the version tag wrong. In those cases, they can simply publish a new release with a different tag and they're fine.