### PR TITLE
Control over caching pre-release, stable release or latest

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -75,7 +75,7 @@ module.exports = class Cache {
   }
 
   async refreshCache() {
-    const { account, repository, pre, token } = this.config
+    const { account, repository, pre, only_pre, token } = this.config
     const repo = account + '/' + repository
     const url = `https://api.github.com/repos/${repo}/releases?per_page=100`
     const headers = { Accept: 'application/vnd.github.preview' }
@@ -106,8 +106,14 @@ module.exports = class Cache {
     }
 
     const release = data.find(item => {
-      const isPre = Boolean(pre) === Boolean(item.prerelease)
-      return !item.draft && isPre
+      if (item.draft) return false
+      if (only_pre) {
+        return item.prerelease
+      }
+      if (!pre) {
+        return !item.prerelease
+      }
+      return true
     })
 
     if (!release || !release.assets || !Array.isArray(release.assets)) {
@@ -127,6 +133,7 @@ module.exports = class Cache {
     this.latest.version = tag_name
     this.latest.notes = release.body
     this.latest.pub_date = release.published_at
+    this.latest.prerelease = release.prerelease
 
     // Clear list of download links
     this.latest.platforms = {}

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ const {
   ACCOUNT: account,
   REPOSITORY: repository,
   PRE: pre,
+  ONLY_PRE: only_pre,
   TOKEN: token,
   URL: PRIVATE_BASE_URL,
   VERCEL_URL
@@ -17,6 +18,7 @@ module.exports = hazel({
   account,
   repository,
   pre,
+  only_pre,
   token,
   url
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -50,6 +50,42 @@ describe('Cache', () => {
     expect(typeof storage.platforms).toBe('object')
   })
 
+  it('a pre-release is cached', async () => {
+    const config = {
+      account: 'zeit',
+      repository: 'hyper',
+      token: process.env.TOKEN,
+      url: process.env.URL,
+      pre: false,
+      only_pre: true
+    }
+
+    const cache = new Cache(config)
+    await cache.refreshCache()
+    const storage = cache.loadCache()
+
+    expect(typeof storage.version).toBe('string')
+    expect(typeof storage.platforms).toBe('object')
+    expect(storage.prerelease).toBe(true)
+  })
+
+  it('a stable release is cached', async () => {
+    const config = {
+      account: 'zeit',
+      repository: 'hyper',
+      token: process.env.TOKEN,
+      url: process.env.URL
+    }
+
+    const cache = new Cache(config)
+    await cache.refreshCache()
+    const storage = cache.loadCache()
+
+    expect(typeof storage.version).toBe('string')
+    expect(typeof storage.platforms).toBe('object')
+    expect(storage.prerelease).toBe(false)
+  })
+
   it('should set platforms correctly', async () => {
     const config = {
       account: 'zeit',


### PR DESCRIPTION
Fixes #20 

- Adds `ONLY_PRE` environment variable. When set, the latest pre-release is cached.
- If the `PRE` environment variable is set, pre-releases are considered to be cached depending on if it is the latest. If not set, only stable releases are cached.
- Updated `lint-staged` to `7.2.0` to work with Node.JS 10+.
- Had to add `testURL` in the Jest config due to a JSDom bug described [here](https://github.com/facebook/jest/issues/6766).