### PR TITLE
Allow darwin in the filename for that platform

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -4,7 +4,7 @@ const { extname } = require('path')
 module.exports = fileName => {
   const extension = extname(fileName).split('.')[1]
 
-  if (fileName.includes('mac') && extension === 'zip') {
+  if ((fileName.includes('mac') || fileName.includes('darwin')) && extension === 'zip') {
     return 'darwin'
   }
 


### PR DESCRIPTION
electron-forge's default filename includes darwin in the make file for zip. 
I was not clear how this determined what platform each file belonged to. 