### PR TITLE
Move to Now 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = null

--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,5 @@
+node_modules
+test
+.circleci
+.yarnrc
+.gitignore

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd hazel
 Inside the directory, create a new deployment:
 
 ```bash
-now -e ACCOUNT="<github-account>" REPOSITORY="<github-repository>"
+now -e ACCOUNT="<github-account>" -e REPOSITORY="<github-repository>"
 ```
 
 On the command above, you can define the following environment variables:

--- a/README.md
+++ b/README.md
@@ -17,19 +17,25 @@ The result will be faster and more lightweight than any other solution out there
 
 ## Usage
 
-With [Now CLI](https://zeit.co/download), you can deploy an update server like this:
+With [Now CLI](https://zeit.co/download), you can easily deploy an update server. As the first step, clone the repository:
 
 ```bash
-now zeit/hazel
+git clone https://github.com/zeit/hazel
 ```
 
-Or if you have later versions of now-cli installed.
+Next, move into the directory:
 
 ```bash
-now -V 1 zeit/hazel
+cd hazel
 ```
 
-You'll be asked for the value of two environment variables:
+Inside the directory, create a new deployment:
+
+```bash
+now -e ACCOUNT="<github-account>" REPOSITORY="<github-repository>"
+```
+
+On the command above, you can define the following environment variables:
 
 - `ACCOUNT`: Your username or organisation name on GitHub
 - `REPOSITORY`: The name of the repository to pull releases from

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,7 @@
 // Packages
 const fetch = require('node-fetch')
 const convertStream = require('stream-to-string')
+const ms = require('ms')
 
 // Utilities
 const checkPlatform = require('./platform')
@@ -21,9 +22,12 @@ module.exports = class Cache {
     }
 
     this.latest = {}
+    this.lastUpdate = null;
+
     this.cacheReleaseList = this.cacheReleaseList.bind(this)
     this.refreshCache = this.refreshCache.bind(this)
     this.loadCache = this.loadCache.bind(this)
+    this.isOutdated = this.isOutdated.bind(this)
   }
 
   async cacheReleaseList(url) {
@@ -92,6 +96,7 @@ module.exports = class Cache {
 
     if (this.latest.version === tag_name) {
       console.log('Cached version is the same as latest')
+      this.lastUpdate = Date.now()
       return
     }
 
@@ -137,15 +142,27 @@ module.exports = class Cache {
     }
 
     console.log(`Finished caching version ${tag_name}`)
+    this.lastUpdate = Date.now()
+  }
+
+  isOutdated() {
+    const { lastUpdate, config } = this
+    const { interval = 15 } = config
+
+    if (lastUpdate && (Date.now() - lastUpdate) > ms(`${interval}m`)) {
+      return true
+    }
+
+    return false
   }
 
   // This is a method returning the cache
   // because the cache would otherwise be loaded
   // only once when the index file is parsed
   async loadCache() {
-    const { latest, refreshCache } = this
+    const { latest, refreshCache, isOutdated, lastUpdate } = this
 
-    if (Object.keys(latest).length === 0) {
+    if (!lastUpdate || isOutdated()) {
       await refreshCache()
     }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -142,7 +142,13 @@ module.exports = class Cache {
   // This is a method returning the cache
   // because the cache would otherwise be loaded
   // only once when the index file is parsed
-  loadCache() {
-    return this.latest
+  async loadCache() {
+    const { latest, refreshCache } = this
+
+    if (Object.keys(latest).length === 0) {
+      await refreshCache()
+    }
+
+    return latest
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,33 +1,16 @@
 // Packages
 const Router = require('router')
 const finalhandler = require('finalhandler')
-const ms = require('ms')
 const Cache = require('./cache')
 
 module.exports = config => {
   // Utilities
   const cache = new Cache(config)
-  const { refreshCache } = cache
   const routes = require('./routes')({ cache, config })
 
   // Initialize a new router
   const router = Router()
 
-  const refresh = () => {
-    try {
-      refreshCache()
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
-  // Load most recent release
-  refresh()
-
-  // Refresh cache every 15 minutes or as defined
-  const { interval = 15 } = config
-
-  setInterval(refresh, ms(`${interval}m`))
   // Define a route for every relevant path
   router.get('/', routes.overview)
   router.get('/download', routes.download)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -33,7 +33,7 @@ module.exports = ({ cache, config }) => {
     })
   }
 
-  exports.download = (req, res) => {
+  exports.download = async (req, res) => {
     const userAgent = parse(req.headers['user-agent'])
     let platform
 
@@ -44,7 +44,7 @@ module.exports = ({ cache, config }) => {
     }
 
     // Get the latest version from the cache
-    const { platforms } = loadCache()
+    const { platforms } = await loadCache()
 
     if (!platform || !platforms || !platforms[platform]) {
       send(res, 404, 'No download available for your platform!')
@@ -63,11 +63,11 @@ module.exports = ({ cache, config }) => {
     res.end()
   }
 
-  exports.downloadPlatform = (req, res) => {
+  exports.downloadPlatform = async (req, res) => {
     let { platform } = req.params
 
     // Get the latest version from the cache
-    const latest = loadCache()
+    const latest = await loadCache()
 
     // Check platform for appropiate aliases
     platform = checkAlias(platform)
@@ -94,7 +94,7 @@ module.exports = ({ cache, config }) => {
     res.end()
   }
 
-  exports.update = (req, res) => {
+  exports.update = async (req, res) => {
     const { platform: platformName, version } = req.params
 
     if (!valid(version)) {
@@ -118,7 +118,7 @@ module.exports = ({ cache, config }) => {
     }
 
     // Get the latest version from the cache
-    const latest = loadCache()
+    const latest = await loadCache()
 
     if (!latest.platforms || !latest.platforms[platform]) {
       res.statusCode = 204
@@ -156,9 +156,9 @@ module.exports = ({ cache, config }) => {
     res.end()
   }
 
-  exports.releases = (req, res) => {
+  exports.releases = async (req, res) => {
     // Get the latest version from the cache
-    const latest = loadCache()
+    const latest = await loadCache()
 
     if (!latest.files || !latest.files.RELEASES) {
       res.statusCode = 204
@@ -178,18 +178,20 @@ module.exports = ({ cache, config }) => {
   }
 
   exports.overview = async (req, res) => {
+    const latest = await loadCache()
+
     try {
       const render = await prepareView()
 
       const details = {
         account: config.account,
         repository: config.repository,
-        date: distanceInWordsToNow(cache.latest.pub_date, { addSuffix: true }),
-        files: cache.latest.platforms,
-        version: cache.latest.version,
+        date: distanceInWordsToNow(latest.pub_date, { addSuffix: true }),
+        files: latest.platforms,
+        version: latest.version,
         releaseNotes: `https://github.com/${config.account}/${
           config.repository
-        }/releases/tag/${cache.latest.version}`,
+        }/releases/tag/${latest.version}`,
         allReleases: `https://github.com/${config.account}/${
           config.repository
         }/releases`,

--- a/now.json
+++ b/now.json
@@ -1,4 +1,16 @@
 {
     "version": 2,
-    "name": "hazel"
+    "name": "hazel",
+    "builds": [
+        {
+            "src": "lib/server.js",
+            "use": "@now/node"
+        }
+    ],
+    "routes": [
+        {
+            "src": ".*",
+            "dest": "/lib/server.js"
+        }
+    ]
 }

--- a/now.json
+++ b/now.json
@@ -1,0 +1,4 @@
+{
+    "version": 2,
+    "name": "hazel"
+}

--- a/package.json
+++ b/package.json
@@ -22,18 +22,6 @@
       "no-await-in-loop": 0
     }
   },
-  "now": {
-    "env": [
-      "ACCOUNT",
-      "REPOSITORY"
-    ],
-    "files": [
-      "lib",
-      "views",
-      "package-lock.json",
-      "package.json"
-    ]
-  },
   "lint-staged": {
     "*.js": [
       "yarn test",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "lib/index.js",
   "description": "Lightweight update server for Electron apps",
   "scripts": {
-    "start": "micro -p ${PORT:-3000} lib/server.js",
     "dev": "micro-dev lib/server.js",
     "test": "xo && jest",
     "precommit": "lint-staged"
@@ -36,7 +35,7 @@
     "finalhandler": "1.1.0",
     "handlebars": "4.0.11",
     "jest": "22.4.0",
-    "micro": "9.1.0",
+    "micro": "9.3.3",
     "ms": "2.1.1",
     "node-fetch": "2.0.0",
     "router": "1.3.2",

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -44,8 +44,7 @@ describe('Cache', () => {
     }
 
     const cache = new Cache(config)
-    await cache.refreshCache()
-    const storage = cache.loadCache()
+    const storage = await cache.loadCache()
 
     expect(typeof storage.version).toBe('string')
     expect(typeof storage.platforms).toBe('object')
@@ -60,9 +59,8 @@ describe('Cache', () => {
     }
 
     const cache = new Cache(config)
-    await cache.refreshCache()
+    const storage = await cache.loadCache()
 
-    const storage = cache.loadCache()
     console.log(storage.platforms.darwin)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,13 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
 any-observable@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
@@ -161,6 +168,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-2.0.0.tgz#c06e7ff69ab05b3a4a03ebe0407fac4cba657545"
+  integrity sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -632,6 +644,15 @@ chalk@2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
+  integrity sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -3300,6 +3321,17 @@ micro@9.1.0:
     mri "1.1.0"
     raw-body "2.3.2"
 
+micro@9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/micro/-/micro-9.3.3.tgz#32728c7be15e807691ead85da27fd8117a8bca24"
+  integrity sha512-GbCp4NFQguARch0odX+BuWDja2Kc1pbYZqWfRvEDihGFTJG8U77C0L+Owg2j7TPyhQ5Tc+7z/SxspRqjdiZCjQ==
+  dependencies:
+    arg "2.0.0"
+    chalk "2.4.0"
+    content-type "1.0.4"
+    is-stream "1.1.0"
+    raw-body "2.3.2"
+
 micromatch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
@@ -4695,6 +4727,13 @@ supports-color@^4.0.0:
 supports-color@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
With this change, we default to the latest version of the Now platform ([2.0](https://zeit.co/blog/now-2)).