### PR TITLE
Allow custom platform handling, DMG files, more Darwin aliases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,3 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
 # editorconfig-tools is unable to ignore longs strings or urls
-max_line_length = null

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -6,18 +6,13 @@ const aliases = {
   AppImage: ['appimage']
 }
 
-module.exports = platform => {
-  if(typeof aliases[platform] !== 'undefined') {
-    return platform
-  }
+const aliasMap = new Map()
+Object.entries(aliases).forEach(([platform, aliases]) => {
+  aliases.forEach(alias => aliasMap.set(alias, platform))
+  aliasMap.set(platform, platform)
+})
 
-  for (const guess of Object.keys(aliases)) {
-    const list = aliases[guess]
-
-    if (list.includes(platform)) {
-      return guess
-    }
-  }
-
-  return false
+module.exports = (platform, customPlatforms = {}) => {
+  if (customPlatforms[platform]) return platform
+  return aliasMap.get(platform) || false
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,6 +2,9 @@
 const fetch = require('node-fetch')
 const convertStream = require('stream-to-string')
 const ms = require('ms')
+const qs = require('tiny-params')
+const { parse } = require('express-useragent')
+const checkAlias = require('./aliases')
 
 // Utilities
 const checkPlatform = require('./platform')
@@ -18,13 +21,15 @@ module.exports = class Cache {
     }
 
     if (token && !url) {
-      const error = new Error('Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode')
+      const error = new Error(
+        'Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode'
+      )
       error.code = 'missing_configuration_properties'
       throw error
     }
 
     this.latest = {}
-    this.lastUpdate = null;
+    this.lastUpdate = null
 
     this.cacheReleaseList = this.cacheReleaseList.bind(this)
     this.refreshCache = this.refreshCache.bind(this)
@@ -151,7 +156,7 @@ module.exports = class Cache {
     const { lastUpdate, config } = this
     const { interval = 15 } = config
 
-    if (lastUpdate && (Date.now() - lastUpdate) > ms(`${interval}m`)) {
+    if (lastUpdate && Date.now() - lastUpdate > ms(`${interval}m`)) {
       return true
     }
 
@@ -169,5 +174,43 @@ module.exports = class Cache {
     }
 
     return latest
+  }
+
+  async getLatestForPlatform(req, isUpdate) {
+    const latest = await this.loadCache()
+    const config = this.config
+
+    const asLatest = (latest, platform, asset) => {
+      return { latest, platform, asset }
+    }
+
+    if (!latest || !latest.platforms) return asLatest()
+
+    const { platforms } = latest
+
+    const { filetype } = qs(req.url)
+    let { platform } = req.params
+
+    if (!platform) {
+      const userAgent = parse(req.headers['user-agent'])
+
+      if (userAgent.isMac) {
+        platform = 'darwin'
+      } else if (userAgent.isWindows) {
+        platform = 'exe'
+      }
+    }
+
+    platform = checkAlias(platform, config.platformHandlers)
+
+    if (!platform) return asLatest(latest)
+
+    const latestForPlatform = platforms[platform]
+
+    const modifiers = {
+      darwin: isUpdate || filetype === 'zip' ? latestForPlatform : platforms.dmg
+    }
+
+    return asLatest(latest, platform, modifiers[platform] || latestForPlatform)
   }
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,6 +5,7 @@ const ms = require('ms')
 const qs = require('tiny-params')
 const { parse } = require('express-useragent')
 const checkAlias = require('./aliases')
+const { proxyReleaseDownload } = require('./util')
 
 // Utilities
 const checkPlatform = require('./platform')
@@ -37,15 +38,19 @@ module.exports = class Cache {
     this.isOutdated = this.isOutdated.bind(this)
   }
 
-  async cacheReleaseList(url) {
+  async cacheReleaseList(asset) {
+    const { browser_download_url: url } = asset
     const { token } = this.config
     const headers = { Accept: 'application/vnd.github.preview' }
+    const shouldProxy = token && typeof token === 'string' && token.length > 0
 
-    if (token && typeof token === 'string' && token.length > 0) {
-      headers.Authorization = `token ${token}`
+    const handler = () => {
+      return shouldProxy
+        ? proxyReleaseDownload(asset, token)
+        : fetch(url, { headers })
     }
 
-    const { status, body } = await fetch(url, { headers })
+    const { status, body } = await handler()
 
     if (status !== 200) {
       throw new Error(
@@ -124,9 +129,7 @@ module.exports = class Cache {
           if (!this.latest.files) {
             this.latest.files = {}
           }
-          this.latest.files.RELEASES = await this.cacheReleaseList(
-            browser_download_url
-          )
+          this.latest.files.RELEASES = await this.cacheReleaseList(asset)
         } catch (err) {
           console.error(err)
         }

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,19 +1,22 @@
 // Native
 const { extname } = require('path')
 
-module.exports = fileName => {
-  const extension = extname(fileName).split('.')[1]
+const extHandlers = {
+  exe: () => 'exe',
+  dmg: () => 'dmg',
+  rpm: () => 'rpm',
+  deb: () => 'deb',
+  AppImage: () => 'AppImage',
+  zip: fname => (fname.match(/mac|osx|darwin/) ? 'darwin' : false)
+}
 
-  if (fileName.includes('mac') && extension === 'zip') {
-    return 'darwin'
+module.exports = (fileName, customPlatforms) => {
+  if (customPlatforms) {
+    const filter = ([_, handler]) => handler(fileName)
+    const [platform] = Object.entries(customPlatforms).find(filter) || []
+    if (platform) return platform
   }
 
-  const directCache = ['exe', 'rpm', 'deb', 'AppImage']
-  const index = directCache.indexOf(extension)
-
-  if (index > -1) {
-    return directCache[index]
-  }
-
-  return false
+  const ext = extname(fileName).split('.')[1]
+  return extHandlers[ext] ? extHandlers[ext](fileName) : false
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -21,7 +21,7 @@ module.exports = ({ cache, config }) => {
     }
 
     if (shouldProxyPrivateDownload) {
-      proxyPrivateDownload(asset, req, res, token)
+      proxyPrivateDownload(asset, token, res)
       return
     }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,101 +1,41 @@
 // Packages
 const { send } = require('micro')
 const { valid, compare } = require('semver')
-const { parse } = require('express-useragent')
-const fetch = require('node-fetch')
 const distanceInWordsToNow = require('date-fns/distance_in_words_to_now')
-
-// Utilities
-const checkAlias = require('./aliases')
+const { proxyPrivateDownload, filetypeForUpdate } = require('./util')
 const prepareView = require('./view')
 
 module.exports = ({ cache, config }) => {
-  const { loadCache } = cache
   const exports = {}
+  const { loadCache } = cache
   const { token, url } = config
   const shouldProxyPrivateDownload =
     token && typeof token === 'string' && token.length > 0
 
-  // Helpers
-  const proxyPrivateDownload = (asset, req, res) => {
-    const redirect = 'manual'
-    const headers = { Accept: 'application/octet-stream' }
-    const options = { headers, redirect }
-    const { api_url: rawUrl } = asset
-    const url = rawUrl.replace(
-      'https://api.github.com/',
-      `https://${token}@api.github.com/`
-    )
-
-    fetch(url, options).then(assetRes => {
-      res.setHeader('Location', assetRes.headers.get('Location'))
-      send(res, 302)
-    })
-  }
-
   exports.download = async (req, res) => {
-    const userAgent = parse(req.headers['user-agent'])
-    let platform
+    const { asset } = await cache.getLatestForPlatform(req)
 
-    if (userAgent.isMac) {
-      platform = 'darwin'
-    } else if (userAgent.isWindows) {
-      platform = 'exe'
-    }
-
-    // Get the latest version from the cache
-    const { platforms } = await loadCache()
-
-    if (!platform || !platforms || !platforms[platform]) {
-      send(res, 404, 'No download available for your platform!')
-      return
-    }
-
-    if (shouldProxyPrivateDownload) {
-      proxyPrivateDownload(platforms[platform], req, res)
-      return
-    }
-
-    res.writeHead(302, {
-      Location: platforms[platform].url
-    })
-
-    res.end()
-  }
-
-  exports.downloadPlatform = async (req, res) => {
-    let { platform } = req.params
-
-    // Get the latest version from the cache
-    const latest = await loadCache()
-
-    // Check platform for appropiate aliases
-    platform = checkAlias(platform)
-
-    if (!platform) {
-      send(res, 500, 'The specified platform is not valid')
-      return
-    }
-
-    if (!latest.platforms || !latest.platforms[platform]) {
+    if (!asset) {
       send(res, 404, 'No download available for your platform')
       return
     }
 
-    if (token && typeof token === 'string' && token.length > 0) {
-      proxyPrivateDownload(latest.platforms[platform], req, res)
+    if (shouldProxyPrivateDownload) {
+      proxyPrivateDownload(asset, req, res, token)
       return
     }
 
     res.writeHead(302, {
-      Location: latest.platforms[platform].url
+      Location: asset.url
     })
 
     res.end()
   }
 
+  exports.downloadPlatform = exports.download
+
   exports.update = async (req, res) => {
-    const { platform: platformName, version } = req.params
+    const { version } = req.params
 
     if (!valid(version)) {
       send(res, 500, {
@@ -106,21 +46,12 @@ module.exports = ({ cache, config }) => {
       return
     }
 
-    const platform = checkAlias(platformName)
+    const { latest, asset, platform } = await cache.getLatestForPlatform(
+      req,
+      true
+    )
 
-    if (!platform) {
-      send(res, 500, {
-        error: 'invalid_platform',
-        message: 'The specified platform is not valid'
-      })
-
-      return
-    }
-
-    // Get the latest version from the cache
-    const latest = await loadCache()
-
-    if (!latest.platforms || !latest.platforms[platform]) {
+    if (!asset) {
       res.statusCode = 204
       res.end()
 
@@ -138,14 +69,14 @@ module.exports = ({ cache, config }) => {
     // a patch update.
 
     if (compare(latest.version, version) !== 0) {
-      const { notes, pub_date } = latest
+      const filetype = filetypeForUpdate(platform)
 
       send(res, 200, {
         name: latest.version,
-        notes,
-        pub_date,
+        notes: latest.notes,
+        pub_date: latest.pub_date,
         url: shouldProxyPrivateDownload
-          ? `${url}/download/${platformName}`
+          ? `${url}/download/${platform}${filetype}`
           : latest.platforms[platform].url
       })
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,24 +1,34 @@
 const fetch = require('node-fetch')
 const { send } = require('micro')
 
-const proxyPrivateDownload = (asset, req, res, token) => {
+const _proxyDownload = async (asset, token, res) => {
+  const isClientDownload = Boolean(res)
   const redirect = 'manual'
   const headers = { Accept: 'application/octet-stream' }
   const options = { headers, redirect }
-  const { api_url: rawUrl } = asset
+  const rawUrl = isClientDownload ? asset.api_url : asset.url
   const url = rawUrl.replace(
     'https://api.github.com/',
     `https://${token}@api.github.com/`
   )
 
-  fetch(url, options).then(assetRes => {
-    res.setHeader('Location', assetRes.headers.get('Location'))
-    send(res, 302)
-  })
+  const { headers: resHeaders } = await fetch(url, options)
+  const location = resHeaders.get('Location') || resHeaders.get('location')
+
+  if (!isClientDownload) return fetch(location, { headers })
+
+  res.setHeader('Location', location)
+  send(res, 302)
 }
+
+const proxyReleaseDownload = (asset, token) => _proxyDownload(asset, token)
 
 const filetypeForUpdate = platform => {
   return platform === 'darwin' ? `?filetype=zip` : ''
 }
 
-module.exports = { filetypeForUpdate, proxyPrivateDownload }
+module.exports = {
+  filetypeForUpdate,
+  proxyReleaseDownload,
+  proxyPrivateDownload: _proxyDownload
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,24 @@
+const fetch = require('node-fetch')
+const { send } = require('micro')
+
+const proxyPrivateDownload = (asset, req, res, token) => {
+  const redirect = 'manual'
+  const headers = { Accept: 'application/octet-stream' }
+  const options = { headers, redirect }
+  const { api_url: rawUrl } = asset
+  const url = rawUrl.replace(
+    'https://api.github.com/',
+    `https://${token}@api.github.com/`
+  )
+
+  fetch(url, options).then(assetRes => {
+    res.setHeader('Location', assetRes.headers.get('Location'))
+    send(res, 302)
+  })
+}
+
+const filetypeForUpdate = platform => {
+  return platform === 'darwin' ? `?filetype=zip` : ''
+}
+
+module.exports = { filetypeForUpdate, proxyPrivateDownload }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "router": "1.3.2",
     "semver": "5.5.0",
     "stream-to-string": "1.1.0",
-    "test-listen": "1.1.0"
+    "test-listen": "1.1.0",
+    "tiny-params": "2.0.4"
   },
   "devDependencies": {
     "eslint-config-prettier": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "micro-dev lib/server.js",
     "test": "xo && jest",
-    "precommit": "lint-staged"
+    "precommit": "yarn test && lint-staged"
   },
   "license": "MIT",
   "repository": "zeit/hazel",
@@ -23,7 +23,6 @@
   },
   "lint-staged": {
     "*.js": [
-      "yarn test",
       "prettier --single-quote --no-semi --write",
       "git add"
     ]

--- a/test/aliases.test.js
+++ b/test/aliases.test.js
@@ -16,4 +16,14 @@ describe('Aliases', () => {
     const result = aliases('test')
     expect(result).toBe(false)
   })
+
+  it('Should handle custom platforms', () => {
+    let result
+
+    result = aliases('custom')
+    expect(result).toBe(false)
+
+    result = aliases('custom', { custom: () => {} })
+    expect(result).toBe('custom')
+  })
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -61,6 +61,7 @@ describe('Cache', () => {
     const cache = new Cache(config)
     const storage = await cache.loadCache()
 
-    console.log(storage.platforms.darwin)
+    // We expect the `darwin` platform to return a `zip` file for hyper
+    expect(storage.platforms.darwin.content_type).toBe('application/zip')
   })
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -65,3 +65,27 @@ describe('Cache', () => {
     expect(storage.platforms.darwin.content_type).toBe('application/zip')
   })
 })
+
+describe('cache.getLatestForPlatform', () => {
+  it('should get latest for platform based on req params', async () => {
+    const config = {
+      account: 'zeit',
+      repository: 'hyper',
+      token: process.env.TOKEN,
+      url: process.env.URL
+    }
+
+    const cache = new Cache(config)
+
+    const req = { url: '', params: { platform: 'darwin' } }
+    const { latest, platform, asset } = await cache.getLatestForPlatform(req)
+
+    expect(typeof latest.version).toBe('string')
+    expect(typeof latest.platforms).toBe('object')
+
+    expect(platform).toBe('darwin')
+
+    expect(typeof asset).toBe('object')
+    expect(typeof asset.name).toBe('string')
+  })
+})

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -16,4 +16,16 @@ describe('Platform', () => {
     const result = platform('hi.txt')
     expect(result).toBe(false)
   })
+
+  it('Should prioritize custom platforms', () => {
+    const custom = fname => fname.indexOf('my-platform') !== -1
+
+    let result
+
+    result = platform('my-platform.exe')
+    expect(result).toBe('exe')
+
+    result = platform('my-platform.exe', { custom })
+    expect(result).toBe('custom')
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5857,6 +5857,11 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
+tiny-params@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-params/-/tiny-params-2.0.4.tgz#4d4018e166f1c4e4fd22d94ff829f908d388293a"
+  integrity sha512-nqabD6uAeARJA1buJNdy36rOPICkidpccz0B8IvUeHKrHGLP5QBbWmqLQjrPV6JYsOuAnA032TntVqVpUS9FEQ==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
This is a pretty exhaustive PR so I totally understand if it doesn't make sense as is. Several of the pieces are pretty tightly interwoven which is why I thought I'd try a first pass as a single PR.

Let me know if there are pieces that would be merged and others that wouldn't and I'll try to break it up respectively.

So, here's all that going on. I've also tried to keep extensive notes on each commit:

- Add ability to have custom platforms in the programmatic usage
  - Pass `customPlatforms` object into config
  - Keys should be platform name
  - Values should be function that gets the asset filename and returns true if it matches platform
- Allow `.dmg` files for darwin
  - DMG's are given priority for darwin download routes
  - ZIPs are used specifically for public updates and private repo update URLs
- Add 'osx' and 'darwin' to platform check for ZIP files
- Fix precommit hooks, as they were failing for me on fresh clone under both Windows and Ubuntu
  - Remove invalid specfication of max_line_width
  - Don't run `yarn test` against each staged JS file, run it before `lint-staged`
- Fix RELEASE file caching for private repos

In addition to these functional enhancements I did rework some things to make the implementation of each more streamlined. The aliases, platform, and routes all underwent significant changes. The logic for `download` and `downloadPlatform` were mostly duplicated and I needed to add more to them each, so I extracted much of the shared logic into an instance method in `Cache`, namely `cache.getLatestForPlatform`. Now `downloadPlatform` is simply an alias for `download`.

I think that covers all the changes. 

* Note: For implementing the `dmg` vs `zip` for private repos I needed a way to specify on the return download to use a zip file for the update action. For that I copied the `nuts` approach of appending a query string "?filetype=zip". For parsing that I added my own module `tiny-params` but ultimately for the limited parsing that's begin done that could just as easily be manually checked. I'll be glad to add a commit changing that to exclude added dependencies.