### PR TITLE
Fixes the runtime error when deployed

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-const hazel = require('.')
+const hazel = require('./index')
 
 const {
   INTERVAL: interval,


### PR DESCRIPTION
Issue with the previous `require('.')`:
```
START RequestId: 1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da Version: $LATEST
2019-08-19T15:02:31.517Z    1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da    Cannot find module '.'
2019-08-19T15:02:31.517Z    1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da    Did you forget to add it to "dependencies" in `package.json`?
END RequestId: 1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da
REPORT RequestId: 1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da    
Duration: 38.26 ms  Billed Duration: 100 ms   Memory Size: 3008 MB  Max Memory Used: 23 MB    
RequestId: 1b0e0445-fb96-4ec8-bb2c-e33bcf21e6da Process exited before completing request
```