### PR TITLE
Add `/download/dmg` support

### DIFF
--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -3,11 +3,12 @@ const aliases = {
   exe: ['win32', 'windows', 'win'],
   deb: ['debian'],
   rpm: ['fedora'],
-  AppImage: ['appimage']
+  AppImage: ['appimage'],
+  dmg: ['dmg']
 }
 
 module.exports = platform => {
-  if(typeof aliases[platform] !== 'undefined') {
+  if (typeof aliases[platform] !== 'undefined') {
     return platform
   }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -19,13 +19,15 @@ module.exports = class Cache {
     }
 
     if (token && !url) {
-      const error = new Error('Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode')
+      const error = new Error(
+        'Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode'
+      )
       error.code = 'missing_configuration_properties'
       throw error
     }
 
     this.latest = {}
-    this.lastUpdate = null;
+    this.lastUpdate = null
 
     this.cacheReleaseList = this.cacheReleaseList.bind(this)
     this.refreshCache = this.refreshCache.bind(this)
@@ -41,17 +43,20 @@ module.exports = class Cache {
       headers.Authorization = `token ${token}`
     }
 
-    const { status, body } = await retry(async () => {
-      const response = await fetch(url, { headers })
+    const { status, body } = await retry(
+      async () => {
+        const response = await fetch(url, { headers })
 
-      if (response.status !== 200) {
-        throw new Error(
-          `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
-        )
-      }
+        if (response.status !== 200) {
+          throw new Error(
+            `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
+          )
+        }
 
-      return response;
-    }, { retries: 3 });
+        return response
+      },
+      { retries: 3 }
+    )
 
     const content = await convertStream(body)
     const matches = content.match(/[^ ]*\.nupkg/gim)
@@ -76,17 +81,20 @@ module.exports = class Cache {
       headers.Authorization = `token ${token}`
     }
 
-    const response = await retry(async () => {
-      const response = await fetch(url, { headers })
+    const response = await retry(
+      async () => {
+        const response = await fetch(url, { headers })
 
-      if (response.status !== 200) {
-        throw new Error(
-          `GitHub API responded with ${response.status} for url ${url}`
-        )
-      }
+        if (response.status !== 200) {
+          throw new Error(
+            `GitHub API responded with ${response.status} for url ${url}`
+          )
+        }
 
-      return response;
-    }, { retries: 3 });
+        return response
+      },
+      { retries: 3 }
+    )
 
     const data = await response.json()
 
@@ -160,7 +168,7 @@ module.exports = class Cache {
     const { lastUpdate, config } = this
     const { interval = 15 } = config
 
-    if (lastUpdate && (Date.now() - lastUpdate) > ms(`${interval}m`)) {
+    if (lastUpdate && Date.now() - lastUpdate > ms(`${interval}m`)) {
       return true
     }
 
@@ -177,6 +185,6 @@ module.exports = class Cache {
       await refreshCache()
     }
 
-    return latest
+    return Object.assign({}, latest)
   }
 }

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -2,18 +2,15 @@
 const { extname } = require('path')
 
 module.exports = fileName => {
-  const extension = extname(fileName).split('.')[1]
+  const extension = extname(fileName).slice(1)
 
-  if ((fileName.includes('mac') || fileName.includes('darwin')) && extension === 'zip') {
+  if (
+    (fileName.includes('mac') || fileName.includes('darwin')) &&
+    extension === 'zip'
+  ) {
     return 'darwin'
   }
 
-  const directCache = ['exe', 'rpm', 'deb', 'AppImage']
-  const index = directCache.indexOf(extension)
-
-  if (index > -1) {
-    return directCache[index]
-  }
-
-  return false
+  const directCache = ['exe', 'dmg', 'rpm', 'deb', 'AppImage']
+  return directCache.find(ext => ext === extension) || false
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -180,6 +180,14 @@ module.exports = ({ cache, config }) => {
   exports.overview = async (req, res) => {
     const latest = await loadCache()
 
+    // Filter out special platforms that should not
+    // be shown on the overview page
+    Object.keys(latest.platforms).forEach(platform => {
+      if (platform === 'dmg') {
+        delete latest.platforms[platform]
+      }
+    })
+
     try {
       const render = await prepareView()
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Lightweight update server for Electron apps",
   "scripts": {
     "dev": "micro-dev lib/server.js",
-    "test": "xo && jest && exit $?",
+    "test": "xo && jest",
     "precommit": "lint-staged"
   },
   "license": "MIT",
@@ -23,7 +23,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "yarn test",
+      "yarn test && :",
       "prettier --single-quote --no-semi --write --no-editorconfig",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Lightweight update server for Electron apps",
   "scripts": {
     "dev": "micro-dev lib/server.js",
-    "test": "xo && jest",
+    "test": "xo && jest && true",
     "precommit": "lint-staged"
   },
   "license": "MIT",
@@ -24,7 +24,7 @@
   "lint-staged": {
     "*.js": [
       "yarn test",
-      "prettier --single-quote --no-semi --write",
+      "prettier --single-quote --no-semi --write --no-editorconfig",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Lightweight update server for Electron apps",
   "scripts": {
     "dev": "micro-dev lib/server.js",
-    "test": "xo && jest && true",
+    "test": "xo && jest && exit $?",
     "precommit": "lint-staged"
   },
   "license": "MIT",

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -12,6 +12,11 @@ describe('Platform', () => {
     expect(result).toBe('deb')
   })
 
+  it('Should parse dmg', () => {
+    const result = platform('hyper-2.1.1.dmg')
+    expect(result).toBe('dmg')
+  })
+
   it('Should return false for unknown files', () => {
     const result = platform('hi.txt')
     expect(result).toBe(false)


### PR DESCRIPTION
Fixes https://github.com/zeit/hazel/issues/61

This adds `/download/dmg` as a hidden route that can be used to download the latest `dmg` file, if there is any.

We don't add it as replacement for `/download/mac` to not break any clients and won't show it on the overview page since it's not a platform itself, our recommended file for mac stays `.zip`.