### PR TITLE
Fix #86 replace all URL matches in RELEASES

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -58,7 +58,7 @@ module.exports = class Cache {
       { retries: 3 }
     )
 
-    const content = await convertStream(body)
+    let content = await convertStream(body)
     const matches = content.match(/[^ ]*\.nupkg/gim)
 
     if (matches.length === 0) {
@@ -67,8 +67,11 @@ module.exports = class Cache {
       )
     }
 
-    const nuPKG = url.replace('RELEASES', matches[0])
-    return content.replace(matches[0], nuPKG)
+    for (let i = 0; i < matches.length; i += 1) {
+      const nuPKG = url.replace('RELEASES', matches[i])
+      content = content.replace(matches[i], nuPKG)
+    }
+    return content
   }
 
   async refreshCache() {


### PR DESCRIPTION
My RELEASES files (generated by my ElectronForge setup) have multiple .nupkg files like this:

```
D457228A4557A98E368607CAEFB2E8359BDE4A2B myproject-0.1.1-beta-full.nupkg 63459818
75301D5E24A475AEA5D75A0794373139ECBC4A6E myproject-0.1.2-beta-full.nupkg 63477557
CAFFA16B7BA8A83C6363ACAA502F5559F4E77EA8 myproject-0.1.3-beta-full.nupkg 63479469
8188E1F52BF93F6C8517E6282C7DCF901A34A124 myproject-0.1.4-beta-delta.nupkg 54311
8D27E34DF34D0D6F1836E70D7C2C7B6AC60A0F14 myproject-0.1.4-beta-full.nupkg 63479551
A49E37D3E3D36910263D02D4BB4812E65E504A43 myproject-0.1.5-delta.nupkg 42460
F98483A029D2684FA1197EAD5B6641F1BCD73416 myproject-0.1.5-full.nupkg 63479677
91F0476B5050D903B8C8AD1EC5152DD9E6EA4A40 myproject-0.1.6-delta.nupkg 118049
934E0D9B673CED9557BC340AC3D80531EF7A51F9 myproject-0.1.6-full.nupkg 63479673
```

The current Hazel implementation edits it and return a file like this: 

```
D457228A4557A98E368607CAEFB2E8359BDE4A2B https://github.com/nathanvogel/myproject-releases/releases/download/v0.1.6/myproject-0.1.1-beta-full.nupkg 63459818
75301D5E24A475AEA5D75A0794373139ECBC4A6E myproject-0.1.2-beta-full.nupkg 63477557
CAFFA16B7BA8A83C6363ACAA502F5559F4E77EA8 myproject-0.1.3-beta-full.nupkg 63479469
8188E1F52BF93F6C8517E6282C7DCF901A34A124 myproject-0.1.4-beta-delta.nupkg 54311
8D27E34DF34D0D6F1836E70D7C2C7B6AC60A0F14 myproject-0.1.4-beta-full.nupkg 63479551
A49E37D3E3D36910263D02D4BB4812E65E504A43 myproject-0.1.5-delta.nupkg 42460
F98483A029D2684FA1197EAD5B6641F1BCD73416 myproject-0.1.5-full.nupkg 63479677
91F0476B5050D903B8C8AD1EC5152DD9E6EA4A40 myproject-0.1.6-delta.nupkg 118049
934E0D9B673CED9557BC340AC3D80531EF7A51F9 myproject-0.1.6-full.nupkg 63479673
```

Because only the first match is being replaced in `cache.js`. Is there a reason for that? Otherwise I think this PR is the expected behaviour.

This fixes #86 and #85 