### PR TITLE
fix: prerelease logic clearer and more reliable

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -105,10 +105,15 @@ module.exports = class Cache {
       return
     }
 
-    const release = data.find(item => {
-      const isPre = Boolean(pre) === Boolean(item.prerelease)
-      return !item.draft && isPre
-    })
+    const isReleaseValid = item => {
+      const wantPreReleases = Boolean(pre);
+      const isPrerelease = Boolean(item.prerelease);
+      const isDraft = Boolean(item.draft);
+      if(isDraft) return false;
+      if(isPrerelease && !wantPreReleases) return false;
+      return true;
+    }
+    const release = data.find(isReleaseValid)
 
     if (!release || !release.assets || !Array.isArray(release.assets)) {
       return


### PR DESCRIPTION
Trying to access releases on my github repository was not working and the logic behind prereleases was kind of confusing. 

This simplifies that logic and makes it more reliable.