### PR TITLE
Catch loadCache errors

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -185,7 +185,7 @@ module.exports = class Cache {
     const { latest, refreshCache, isOutdated, lastUpdate } = this
 
     if (!lastUpdate || isOutdated()) {
-      await refreshCache().catch((error) => console.log(error))
+      await refreshCache().catch((error) => console.error(error))
     }
 
     return Object.assign({}, latest)


### PR DESCRIPTION
Adding a catch statement, to the loadCache API to ensure that for example a GH API error does not take the server down