### PR TITLE
Support linux platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The result will be faster and more lightweight than any other solution out there
 - Pulls the latest release data from [GitHub Releases](https://help.github.com/articles/creating-releases/) and caches it in memory
 - Refreshes the cache every **15 minutes** (custom interval [possible](#options))
 - When asked for an update, it returns the link to the GitHub asset directly (saves bandwidth)
-- Supports **macOS** and **Windows** apps
+- Supports **macOS**, **Windows**, and **Linux** apps
 - Scales infinitely on [Vercel](https://vercel.com) Serverless Functions
 
 ## Usage

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -49,6 +49,8 @@ module.exports = ({ cache, config }) => {
       platform = 'dmg'
     } else if (userAgent.isWindows) {
       platform = 'exe'
+    } else if (userAgent.isLinux) {
+      platform = 'AppImage'
     }
 
     // Get the latest version from the cache


### PR DESCRIPTION
Closes #59

PR makes it so that if a user is on linux, then suggest `AppImage` as the platform for download, where AppImage is the popular way for delivering a single app in a cross-distro way. We've been using this in our own private fork of this repo for years successfully.